### PR TITLE
Update deps + adapt to UnoCSS v66

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
 		"build": "tsc"
 	},
 	"devDependencies": {
-		"@types/node": "^20.14.2",
-		"typescript": "^5.4.5"
+		"@types/node": "^22.13.10",
+		"typescript": "^5.8.2"
 	},
 	"dependencies": {
-		"@unocss/autocomplete": "^0.61.0",
-		"@unocss/config": "^0.61.0",
-		"@unocss/core": "^0.61.0",
-		"@unocss/extractor-arbitrary-variants": "^0.61.0",
-		"@unocss/preset-uno": "^0.61.0",
+		"@unocss/autocomplete": "^66.1.0-beta.5",
+		"@unocss/config": "^66.1.0-beta.5",
+		"@unocss/core": "^66.1.0-beta.5",
+		"@unocss/extractor-arbitrary-variants": "^66.1.0-beta.5",
+		"@unocss/preset-wind3": "^66.1.0-beta.5",
 		"color-rgba": "^3.0.0",
-		"magic-string": "^0.30.10",
-		"unconfig": "^0.3.13",
+		"magic-string": "^0.30.17",
+		"unconfig": "^7.3.1",
 		"vscode-languageserver": "^9.0.1",
-		"vscode-languageserver-textdocument": "^1.0.11"
+		"vscode-languageserver-textdocument": "^1.0.12"	
 	}
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,6 @@
 import { createGenerator } from "@unocss/core";
 import { createAutocomplete, searchUsageBoundary } from "@unocss/autocomplete";
-import preserUno from "@unocss/preset-uno";
+import presetWind3 from "@unocss/preset-wind3";
 import { loadConfig } from "@unocss/config";
 import { sourcePluginFactory, sourceObjectFields } from "unconfig/presets";
 import { CompletionItem } from "vscode-languageserver";
@@ -8,14 +8,14 @@ import { getMatchedPositionsFromCode } from './share-common.js';
 import { getColorString } from './utils.js';
 
 const defaultConfig = {
-  presets: [preserUno()],
+  presets: [presetWind3()],
   separators: []
 };
 
-const generator = createGenerator({}, defaultConfig);
+const generator = await createGenerator({}, defaultConfig);
 let autocomplete = createAutocomplete(generator);
 
-export function resolveConfig(roorDir: string) {
+export async function resolveConfig(roorDir: string) {
   return loadConfig(process.cwd(), roorDir, [
     sourcePluginFactory({
       files: ["vite.config", "svelte.config", "iles.config"],
@@ -30,8 +30,8 @@ export function resolveConfig(roorDir: string) {
       files: "nuxt.config",
       fields: "unocss",
     }),
-  ]).then((result) => {
-    generator.setConfig(result.config, defaultConfig);
+  ]).then(async (result) => {
+    await generator.setConfig(result.config, defaultConfig);
     autocomplete = createAutocomplete(generator);
     return generator.config;
   });

--- a/src/share-common.ts
+++ b/src/share-common.ts
@@ -4,7 +4,7 @@ import MagicString from 'magic-string'
 import { arbitraryPropertyRE, quotedArbitraryValuesRE } from '@unocss/extractor-arbitrary-variants'
 
 // https://github.com/dsblv/string-replace-async/blob/main/index.js
-export function replaceAsync(string: string, searchValue: RegExp, replacer: (...args: string[]) => Promise<string>) {
+export async function replaceAsync(string: string, searchValue: RegExp, replacer: (...args: string[]) => Promise<string>) {
   try {
     if (typeof replacer === 'function') {
       const values: Promise<string>[] = []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "nodenext",
-		"target": "ES2015",
+		"target": "ES2018",
 		"lib": [
 			"es2021"
 		],


### PR DESCRIPTION
The newer versions of `@unocss/core` has asynchronous `createGenerator` and `setConfig`, as evidenced here:

- `createGenerator`: https://github.com/unocss/unocss/blob/v66.0.0/packages-engine/core/src/generator.ts#L926
- `setConfig`: https://github.com/unocss/unocss/blob/v66.0.0/packages-engine/core/src/generator.ts#L44

Aside from dependencies (`@unocss/preset-wind3` succeeding the [deprecated](https://www.npmjs.com/package/@unocss/preset-uno) `@unocss/preset-uno`), I have also made some changes to `tsconfig.json` and several functions (becoming asynchronous) to follow suggestions from TypeScript LSP.