### PR TITLE
fix: read properties of null error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,7 @@ connection.onInitialize((params: InitializeParams) => {
   let rootDir = '';
 
   // check for the worspace capability and if the workspace folders are available
-  if (hasWorkspaceFolderCapability && params.workspaceFolders[0]) {
+  if (hasWorkspaceFolderCapability && params.workspaceFolders && params.workspaceFolders[0]) {
     rootDir = params.workspaceFolders[0].uri || params.workspaceFolders[0].name;
   }
 


### PR DESCRIPTION
The error occurs when opening a file of a type that triggers the `unocss-language-server`, under a directory where no root markers are present. While this issue can be avoided by setting `workspace_required = true` via `vim.lsp.config`, this option is not available as of NeoVim v0.11.0.