### PR TITLE
chore: add Nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 out
+result

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ A language server for unocss
 npm i unocss-language-server -g
 ```
 
+**For Nix users:**
+
+```sh
+# Install
+nix profile install github:xna00/unocss-language-server
+
+# or just run without installing
+nix run github:xna00/unocss-language-server -- --stdio
+```
+
 ## Usage
 
 [nvim-lspconfig server_configuration](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#unocss)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "unocss language server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+      perSystem =
+        { config, pkgs, ... }:
+        {
+          packages = {
+            unocss-language-server = pkgs.callPackage ./package.nix { };
+            default = config.packages.unocss-language-server;
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              pkgs.nodejs
+              pkgs.pnpm
+              pkgs.typescript
+              pkgs.typescript-language-server
+            ];
+          };
+        };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs,
+  pnpm,
+}:
+
+let
+  original = lib.importJSON ./package.json;
+  inherit (original) version description;
+  pname = original.name;
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src = lib.cleanSource ./.;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  prePnpmInstall = "";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      prePnpmInstall
+      ;
+    pnpm = pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-vGSr+nLtV189QVoe1cKZoX+sUhTlqOe+EgurnXHCILY=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm run build
+    runHook postBuild
+  '';
+
+  postBuild = ''
+    pnpm prune --prod
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/lib/${pname}
+
+    cp -r out $out/lib/${pname}/
+    cp -r node_modules $out/lib/${pname}/
+
+    makeWrapper ${nodejs}/bin/node \
+      $out/bin/unocss-language-server \
+      --set NODE_PATH $out/lib/${pname}/node_modules \
+      --add-flags $out/lib/${pname}/out/server.js
+
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit description;
+    mainProgram = pname;
+    license = lib.licenses.mit;
+    homepage = "https://github.com/xna00/unocss-language-server";
+  };
+})


### PR DESCRIPTION
## Summary

- Add a Nix flake that exposes `unocss-language-server` as the default package
- Add `package.nix` for building the language server with pnpm dependencies
- Document the Nix commands in the README
- Ignore the local Nix `result` symlink